### PR TITLE
HHH-19365 - support identity and containsExactlyInAnyOrder

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdAndMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdAndMergeTest.java
@@ -7,13 +7,11 @@ package org.hibernate.orm.test.cid;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.dialect.GaussDBDialect;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
@@ -41,7 +39,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class CompositeIdAndMergeTest {
 
 	@Test
-	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "opengauss don't support identity key generation")
 	public void testMerge(SessionFactoryScope scope) {
 		Integer lineItemIndex = 2;
 		Order persistedOrder = scope.fromTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphAndJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphAndJoinTest.java
@@ -113,7 +113,7 @@ public class EntityGraphAndJoinTest {
 			final List<Person> resultList = query.setHint( HINT_SPEC_FETCH_GRAPH, entityGraph ).getResultList();
 			assertThat( resultList ).hasSize( 2 );
 			// No order by, there is no guarantee of the data order.
-			assertThat( resultList.stream().map( p -> p.getAddress().getId() ) ).contains( 1L, 2L );
+			assertThat( resultList.stream().map( p -> p.getAddress().getId() ) ).containsExactlyInAnyOrder( 1L, 2L );
 			inspector.assertExecutedCount( 1 );
 			inspector.assertNumberOfOccurrenceInQuery( 0, "join", where ? 2 : 1 );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/merge/BidirectionalOneToManyMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/merge/BidirectionalOneToManyMergeTest.java
@@ -5,8 +5,6 @@
 package org.hibernate.orm.test.merge;
 
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.hibernate.dialect.GaussDBDialect;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,7 +46,6 @@ public class BidirectionalOneToManyMergeTest extends org.hibernate.orm.test.jpa.
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "opengauss don't support identity key generation")
 	public void testMerge() {
 		doInJPA(this::entityManagerFactory, entityManager -> {
 			Post post = entityManager.find(Post.class, 1L);


### PR DESCRIPTION
1. support identity 
2. update containsExactlyInAnyOrder
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
